### PR TITLE
Add pause tracking and HH:MM:SS timer display

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,7 +5,8 @@
   const stateKey = "ftl.state.v0.01";
 
   const els = {
-    elapsedHHMM: $("#elapsedHHMM"),
+    elapsedHHMMSS: $("#elapsedHHMMSS"),
+    pausedHHMMSS: $("#pausedHHMMSS"),
     elapsedDec: $("#elapsedDec"),
     startedAt: $("#startedAt"),
     startResumeBtn: $("#startResumeBtn"),
@@ -47,6 +48,10 @@
       lastResumeMs: null,
       // total elapsed not including current run segment
       baseElapsedMs: 0,
+      // when the timer was paused
+      lastPauseMs: null,
+      // total paused time
+      basePausedMs: 0,
     },
     landings: { student: 0, instructor: 0 },
     hobbs: { start: "", stop: "" },
@@ -96,6 +101,10 @@
 
   function startTimer(){
     if(!st.timer.firstStartMs) st.timer.firstStartMs = now();
+    if(st.timer.lastPauseMs){
+      st.timer.basePausedMs += Math.max(0, now() - st.timer.lastPauseMs);
+      st.timer.lastPauseMs = null;
+    }
     st.timer.lastResumeMs = now();
     st.timer.running = true;
     save();
@@ -109,8 +118,8 @@
     st.timer.baseElapsedMs += Math.max(0, delta);
     st.timer.lastResumeMs = null;
     st.timer.running = false;
+    st.timer.lastPauseMs = now();
     save();
-    stopTicking();
     renderTimer();
   }
 
@@ -129,11 +138,19 @@
     return base;
   }
 
-  function msToHHMM(ms){
-    const totalMin = Math.floor(ms/60000);
-    const hh = Math.floor(totalMin / 60);
-    const mm = totalMin % 60;
-    return String(hh).padStart(2,'0') + ":" + String(mm).padStart(2,'0');
+  function getPausedMs(){
+    const base = st.timer.basePausedMs || 0;
+    if(!st.timer.running && st.timer.lastPauseMs){
+      return base + (now() - st.timer.lastPauseMs);
+    }
+    return base;
+  }
+  function msToHHMMSS(ms){
+    const totalSec = Math.floor(ms/1000);
+    const hh = Math.floor(totalSec / 3600);
+    const mm = Math.floor((totalSec % 3600) / 60);
+    const ss = totalSec % 60;
+    return String(hh).padStart(2,'0') + ":" + String(mm).padStart(2,'0') + ":" + String(ss).padStart(2,'0');
   }
 
   function msToDec(ms){
@@ -143,8 +160,10 @@
 
   function renderTimer(){
     const ms = getElapsedMs();
-    els.elapsedHHMM.textContent = msToHHMM(ms);
+    els.elapsedHHMMSS.textContent = msToHHMMSS(ms);
     els.elapsedDec.textContent = msToDec(ms);
+    const pms = getPausedMs();
+    els.pausedHHMMSS.textContent = msToHHMMSS(pms);
     const running = st.timer.running;
     els.timerState.textContent = running ? "running" : "stopped";
     els.timerState.classList.toggle("running", running);
@@ -184,7 +203,7 @@
   });
 
   // Resume ticking if re-opened
-  if(st.timer.running) startTicking();
+  if(st.timer.running || st.timer.lastPauseMs) startTicking();
   renderTimer();
 
   // ==== LANDINGS ====
@@ -325,7 +344,7 @@
     lines.push("Saved: " + updated.toLocaleString());
     lines.push("");
     // Live timer
-    const timerHHMM = document.getElementById("elapsedHHMM").textContent;
+    const timerHHMM = document.getElementById("elapsedHHMMSS").textContent;
     const timerDec = document.getElementById("elapsedDec").textContent;
     const started = document.getElementById("startedAt").textContent;
     lines.push("[Live Timer]");

--- a/index.html
+++ b/index.html
@@ -72,6 +72,7 @@
     }
     .stat label { display:block; font-size: .9rem; color: var(--muted); }
     .stat .value { font-size: 2rem; font-variant-numeric: tabular-nums; font-weight: 700; }
+    .timer-display .value { font-size: 3rem; }
     .btns { display:flex; gap:8px; flex-wrap: wrap; margin-top:12px; }
     button {
       font: inherit;
@@ -162,8 +163,12 @@
         <h2>Live Flight Timer</h2>
         <div class="timer-display">
           <div class="stat">
-            <label>Elapsed (HH:MM)</label>
-            <div id="elapsedHHMM" class="value">00:00</div>
+            <label>Elapsed (HH:MM:SS)</label>
+            <div id="elapsedHHMMSS" class="value">00:00:00</div>
+          </div>
+          <div class="stat">
+            <label>Paused (HH:MM:SS)</label>
+            <div id="pausedHHMMSS" class="value">00:00:00</div>
           </div>
           <div class="stat">
             <label>Elapsed (Decimal)</label>


### PR DESCRIPTION
## Summary
- Display elapsed time in HH:MM:SS format and show total pause duration.
- Track pause intervals in timer state and update rendering accordingly.
- Enlarge live flight timer data text for improved readability.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68ad2811d2548326887ecebc79df90a0