### PR TITLE
feat: omit unused fields in summary

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,6 +37,10 @@
     copySummary: $("#copySummary"),
     resetAll: $("#resetAll"),
     installBtn: $("#installBtn"),
+    sumElapsed: $("#sumElapsed"),
+    sumHobbs: $("#sumHobbs"),
+    sumTach: $("#sumTach"),
+    sumManual: $("#sumManual"),
   };
 
   const initial = {
@@ -161,7 +165,9 @@
   function renderTimer(){
     const ms = getElapsedMs();
     els.elapsedHHMMSS.textContent = msToHHMMSS(ms);
-    els.elapsedDec.textContent = msToDec(ms);
+    const dec = msToDec(ms);
+    els.elapsedDec.textContent = dec;
+    els.sumElapsed.textContent = dec;
     const pms = getPausedMs();
     els.pausedHHMMSS.textContent = msToHHMMSS(pms);
     const running = st.timer.running;
@@ -240,12 +246,16 @@
   function renderHobbs(){
     els.hobbsStart.value = st.hobbs.start;
     els.hobbsStop.value = st.hobbs.stop;
-    els.hobbsTotal.textContent = calcDecimal(st.hobbs.start, st.hobbs.stop);
+    const total = calcDecimal(st.hobbs.start, st.hobbs.stop);
+    els.hobbsTotal.textContent = total;
+    els.sumHobbs.textContent = total;
   }
   function renderTach(){
     els.tachStart.value = st.tach.start;
     els.tachStop.value = st.tach.stop;
-    els.tachTotal.textContent = calcDecimal(st.tach.start, st.tach.stop);
+    const total = calcDecimal(st.tach.start, st.tach.stop);
+    els.tachTotal.textContent = total;
+    els.sumTach.textContent = total;
   }
 
   function bindDecimalInput(el, path){
@@ -324,6 +334,7 @@
     }
     els.manHHMM.textContent = hhmm;
     els.manDec.textContent = dec;
+    els.sumManual.textContent = dec;
   }
 
   bindTimeInput(els.manStart, 'manual.start');

--- a/app.js
+++ b/app.js
@@ -344,40 +344,56 @@
     lines.push("Saved: " + updated.toLocaleString());
     lines.push("");
     // Live timer
-    const timerHHMM = document.getElementById("elapsedHHMMSS").textContent;
-    const timerDec = document.getElementById("elapsedDec").textContent;
-    const started = document.getElementById("startedAt").textContent;
-    lines.push("[Live Timer]");
-    lines.push("  Started: " + started);
-    lines.push("  Elapsed: " + timerHHMM + " (" + timerDec + " h)");
-    lines.push("");
+    if (st.timer.firstStartMs) {
+      const timerHHMM = document.getElementById("elapsedHHMMSS").textContent;
+      const timerDec = document.getElementById("elapsedDec").textContent;
+      const started = document.getElementById("startedAt").textContent;
+      lines.push("[Live Timer]");
+      lines.push("  Started: " + started);
+      lines.push("  Elapsed: " + timerHHMM + " (" + timerDec + " h)");
+      lines.push("");
+    }
     // Landings
-    lines.push("[Landings]");
-    lines.push("  Student: " + st.landings.student);
-    lines.push("  Instructor: " + st.landings.instructor);
-    lines.push("");
+    if (st.landings.student > 0 || st.landings.instructor > 0) {
+      lines.push("[Landings]");
+      if (st.landings.student > 0) lines.push("  Student: " + st.landings.student);
+      if (st.landings.instructor > 0) lines.push("  Instructor: " + st.landings.instructor);
+      lines.push("");
+    }
     // Hobbs
+    const hobbsStart = st.hobbs.start;
+    const hobbsStop = st.hobbs.stop;
     const hobbsTotal = document.getElementById("hobbsTotal").textContent;
-    lines.push("[Hobbs]");
-    lines.push("  Start: " + (st.hobbs.start || "--"));
-    lines.push("  Stop : " + (st.hobbs.stop || "--"));
-    lines.push("  Total: " + hobbsTotal + " h");
-    lines.push("");
+    if (hobbsStart || hobbsStop) {
+      lines.push("[Hobbs]");
+      if (hobbsStart) lines.push("  Start: " + hobbsStart);
+      if (hobbsStop) lines.push("  Stop : " + hobbsStop);
+      if (hobbsStart && hobbsStop) lines.push("  Total: " + hobbsTotal + " h");
+      lines.push("");
+    }
     // Tach
+    const tachStart = st.tach.start;
+    const tachStop = st.tach.stop;
     const tachTotal = document.getElementById("tachTotal").textContent;
-    lines.push("[Tach]");
-    lines.push("  Start: " + (st.tach.start || "--"));
-    lines.push("  Stop : " + (st.tach.stop || "--"));
-    lines.push("  Total: " + tachTotal + " h");
-    lines.push("");
+    if (tachStart || tachStop) {
+      lines.push("[Tach]");
+      if (tachStart) lines.push("  Start: " + tachStart);
+      if (tachStop) lines.push("  Stop : " + tachStop);
+      if (tachStart && tachStop) lines.push("  Total: " + tachTotal + " h");
+      lines.push("");
+    }
     // Manual
+    const manStart = st.manual.start;
+    const manStop = st.manual.stop;
     const manHHMM = document.getElementById("manHHMM").textContent;
     const manDec = document.getElementById("manDec").textContent;
-    lines.push("[Manual Time]");
-    lines.push("  Start: " + (st.manual.start || "--:--"));
-    lines.push("  Stop : " + (st.manual.stop || "--:--"));
-    lines.push("  Elapsed: " + manHHMM + " (" + manDec + " h)");
-    lines.push("");
+    if (manStart || manStop) {
+      lines.push("[Manual Time]");
+      if (manStart) lines.push("  Start: " + manStart);
+      if (manStop) lines.push("  Stop : " + manStop);
+      if (manStart && manStop) lines.push("  Elapsed: " + manHHMM + " (" + manDec + " h)");
+      lines.push("");
+    }
     els.summaryBox.value = lines.join("\n");
   }
   renderSummary();

--- a/index.html
+++ b/index.html
@@ -186,7 +186,7 @@
         </div>
         <div class="btns">
           <button id="startResumeBtn" class="primary">Start</button>
-          <button id="pauseBtn">Pause</button>
+          <button id="pauseBtn" class="warn">Pause</button>
           <button id="resetTimerBtn" class="danger">Reset</button>
           <span id="timerState" class="pill stopped">stopped</span>
         </div>
@@ -285,6 +285,28 @@
         </div>
         <div class="btns">
           <button id="clearManual" class="danger">Reset Manual</button>
+        </div>
+      </section>
+
+      <section class="card" id="liveSummaryCard">
+        <h2>Live Summary</h2>
+        <div class="timer-display">
+          <div class="stat">
+            <label>Elapsed (Decimal)</label>
+            <div id="sumElapsed" class="value">0.00</div>
+          </div>
+          <div class="stat">
+            <label>Hobbs (H.DD)</label>
+            <div id="sumHobbs" class="value">0.00</div>
+          </div>
+          <div class="stat">
+            <label>Tach (H.DD)</label>
+            <div id="sumTach" class="value">0.00</div>
+          </div>
+          <div class="stat">
+            <label>Manual (Decimal)</label>
+            <div id="sumManual" class="value">0.00</div>
+          </div>
         </div>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- include Live Timer, Landings, Hobbs, Tach, and Manual sections in the summary only when they have data
- skip individual field lines if their inputs are blank

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2e915ec8832699e4e20f08c43bd0