### PR TITLE
Add due back time input field

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,6 +28,7 @@
     tachStop: $("#tachStop"),
     tachTotal: $("#tachTotal"),
     clearTach: $("#clearTach"),
+    dueBack: $("#dueBack"),
     manStart: $("#manStart"),
     manStop: $("#manStop"),
     manHHMM: $("#manHHMM"),
@@ -60,6 +61,7 @@
     landings: { student: 0, instructor: 0 },
     hobbs: { start: "", stop: "" },
     tach: { start: "", stop: "" },
+    due: { back: "" },
     manual: { start: "", stop: "" },
     meta: { updatedAt: new Date().toISOString() },
   };
@@ -346,6 +348,13 @@
   });
   renderManual();
 
+  // ==== DUE BACK TIME (HH:MM) ====
+  function renderDue(){
+    els.dueBack.value = st.due.back;
+  }
+  bindTimeInput(els.dueBack, 'due.back');
+  renderDue();
+
   // ==== SUMMARY ====
   function renderSummary(){
     const lines = [];
@@ -391,6 +400,13 @@
       if (tachStart) lines.push("  Start: " + tachStart);
       if (tachStop) lines.push("  Stop : " + tachStop);
       if (tachStart && tachStop) lines.push("  Total: " + tachTotal + " h");
+      lines.push("");
+    }
+    // Due Back
+    const dueBack = st.due.back;
+    if (dueBack) {
+      lines.push("[Due Back]");
+      lines.push("  Time: " + dueBack);
       lines.push("");
     }
     // Manual

--- a/index.html
+++ b/index.html
@@ -260,6 +260,14 @@
         </div>
       </section>
 
+      <section class="card" id="dueBackCard">
+        <h2>Due Back (HH:MM)</h2>
+        <div>
+          <label for="dueBack">Time</label>
+          <input id="dueBack" class="ktime" inputmode="numeric" placeholder="HH:MM">
+        </div>
+      </section>
+
       <section class="card" id="manualCard">
         <h2>Manual Time (HH:MM)</h2>
         <div class="section-row">

--- a/index.html
+++ b/index.html
@@ -164,6 +164,13 @@
 
   <main class="wrap">
     <div class="grid">
+      <section class="card" id="dueBackCard">
+        <h2>Due Back (HH:MM)</h2>
+        <div>
+          <label for="dueBack">Time</label>
+          <input id="dueBack" class="ktime" inputmode="numeric" placeholder="HH:MM">
+        </div>
+      </section>
       <section class="card" id="timerCard" aria-live="polite">
         <h2>Live Flight Timer</h2>
         <div class="timer-display">
@@ -257,14 +264,6 @@
             <div id="tachTotal" class="value">0.00</div>
           </div>
           <button id="clearTach" class="danger">Clear Tach</button>
-        </div>
-      </section>
-
-      <section class="card" id="dueBackCard">
-        <h2>Due Back (HH:MM)</h2>
-        <div>
-          <label for="dueBack">Time</label>
-          <input id="dueBack" class="ktime" inputmode="numeric" placeholder="HH:MM">
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- Add “Due Back” section with HH:MM input for mid-flight reference
- Persist due back time in app state and include in generated summary

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ada65a93648326891a5eb1dec71fb7