### PR TITLE
Add student name field and summary display

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,6 +29,7 @@
     tachTotal: $("#tachTotal"),
     clearTach: $("#clearTach"),
     dueBack: $("#dueBack"),
+    studentName: $("#studentName"),
     manStart: $("#manStart"),
     manStop: $("#manStop"),
     manHHMM: $("#manHHMM"),
@@ -62,6 +63,7 @@
     hobbs: { start: "", stop: "" },
     tach: { start: "", stop: "" },
     due: { back: "" },
+    student: { name: "" },
     manual: { start: "", stop: "" },
     meta: { updatedAt: new Date().toISOString() },
   };
@@ -355,9 +357,23 @@
   bindTimeInput(els.dueBack, 'due.back');
   renderDue();
 
+  // ==== STUDENT NAME ====
+  function renderStudent(){
+    els.studentName.value = st.student.name;
+  }
+  els.studentName.addEventListener("input", (e)=>{
+    st.student.name = e.target.value;
+    save();
+  });
+  renderStudent();
+
   // ==== SUMMARY ====
   function renderSummary(){
     const lines = [];
+    if (st.student.name) {
+      lines.push("Student: " + st.student.name);
+      lines.push("");
+    }
     lines.push("Flight Timer & Log — Summary");
     lines.push("Version: 1.0");
     const updated = new Date(st.meta.updatedAt);

--- a/index.html
+++ b/index.html
@@ -316,6 +316,13 @@
           </div>
         </div>
       </section>
+      <section class="card" id="studentCard">
+        <h2>Student</h2>
+        <div>
+          <label for="studentName">Name</label>
+          <input id="studentName" class="knum" placeholder="Student Name">
+        </div>
+      </section>
     </div>
 
     <section class="card" id="summaryCard" style="margin-top:16px">

--- a/index.html
+++ b/index.html
@@ -295,6 +295,13 @@
         </div>
       </section>
 
+      <section class="card" id="studentCard">
+        <h2>Student</h2>
+        <div>
+          <label for="studentName">Name</label>
+          <input id="studentName" class="knum" placeholder="Student Name">
+        </div>
+      </section>
       <section class="card" id="liveSummaryCard">
         <h2>Live Summary</h2>
         <div class="timer-display">
@@ -314,13 +321,6 @@
             <label>Manual (Decimal)</label>
             <div id="sumManual" class="value">0.00</div>
           </div>
-        </div>
-      </section>
-      <section class="card" id="studentCard">
-        <h2>Student</h2>
-        <div>
-          <label for="studentName">Name</label>
-          <input id="studentName" class="knum" placeholder="Student Name">
         </div>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- Add student name input section near bottom of form
- Persist student name and place at top of generated summary

## Testing
- `node --check app.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adcf58b5f88326adeb5111da3bed1b