### PR TITLE
Allow paused time toggle to decimal

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@
   const els = {
     elapsedHHMMSS: $("#elapsedHHMMSS"),
     pausedHHMMSS: $("#pausedHHMMSS"),
+    pausedLabel: $("#pausedLabel"),
     elapsedDec: $("#elapsedDec"),
     startedAt: $("#startedAt"),
     startResumeBtn: $("#startResumeBtn"),
@@ -102,6 +103,7 @@
 
   // ==== TIMER ====
   let tickHandle = null;
+  let showPausedDec = false;
 
   function now(){
     return Date.now();
@@ -173,7 +175,13 @@
     els.elapsedDec.textContent = dec;
     els.sumElapsed.textContent = dec;
     const pms = getPausedMs();
-    els.pausedHHMMSS.textContent = msToHHMMSS(pms);
+    if(showPausedDec){
+      els.pausedHHMMSS.textContent = msToDec(pms);
+      els.pausedLabel.textContent = "Paused (Decimal)";
+    } else {
+      els.pausedHHMMSS.textContent = msToHHMMSS(pms);
+      els.pausedLabel.textContent = "Paused (HH:MM:SS)";
+    }
     const running = st.timer.running;
     els.timerState.textContent = running ? "running" : "stopped";
     els.timerState.classList.toggle("running", running);
@@ -210,6 +218,10 @@
   els.pauseBtn.addEventListener("click", pauseTimer);
   els.resetTimerBtn.addEventListener("click", ()=>{
     if(confirm("Reset the live timer?")) resetTimer();
+  });
+  els.pausedHHMMSS.addEventListener("click", ()=>{
+    showPausedDec = !showPausedDec;
+    renderTimer();
   });
 
   // Resume ticking if re-opened

--- a/index.html
+++ b/index.html
@@ -72,6 +72,7 @@
     }
     .stat label { display:block; font-size: .9rem; color: var(--muted); }
     .stat .value { font-size: 2rem; font-variant-numeric: tabular-nums; font-weight: 700; }
+    .stat .value.toggle { cursor: pointer; }
     .timer-display .value { font-size: 3rem; }
     .btns { display:flex; gap:8px; flex-wrap: wrap; margin-top:12px; }
     button {
@@ -179,8 +180,8 @@
             <div id="elapsedHHMMSS" class="value">00:00:00</div>
           </div>
           <div class="stat">
-            <label>Paused (HH:MM:SS)</label>
-            <div id="pausedHHMMSS" class="value">00:00:00</div>
+            <label id="pausedLabel">Paused (HH:MM:SS)</label>
+            <div id="pausedHHMMSS" class="value toggle">00:00:00</div>
           </div>
           <div class="stat">
             <label>Elapsed (Decimal)</label>


### PR DESCRIPTION
## Summary
- Allow tapping the paused time display to toggle between HH:MM:SS and decimal hours
- Update label text to reflect the selected format
- Style paused time display as clickable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8260b3dc8326a5a3e89e81f49ef0