### PR TITLE
feat: add manual update button

### DIFF
--- a/app.js
+++ b/app.js
@@ -535,6 +535,7 @@
             }
           });
         });
+        reg.update();
       }).catch((err)=>console.warn('SW registration failed', err));
 
       let refreshing = false;

--- a/app.js
+++ b/app.js
@@ -40,6 +40,7 @@
     copySummary: $("#copySummary"),
     resetAll: $("#resetAll"),
     installBtn: $("#installBtn"),
+    updateBtn: $("#updateBtn"),
     sumElapsed: $("#sumElapsed"),
     sumHobbs: $("#sumHobbs"),
     sumTach: $("#sumTach"),
@@ -516,8 +517,32 @@
   // ==== SW REGISTER ====
   if('serviceWorker' in navigator){
     window.addEventListener('load', ()=>{
-      navigator.serviceWorker.register('service-worker.js')
-        .catch((err)=>console.warn('SW registration failed', err));
+      navigator.serviceWorker.register('service-worker.js').then((reg)=>{
+        function showUpdate(worker){
+          els.updateBtn.style.display = 'inline-block';
+          els.updateBtn.addEventListener('click', ()=>{
+            worker.postMessage({ type: 'SKIP_WAITING' });
+          }, { once: true });
+        }
+        if(reg.waiting){
+          showUpdate(reg.waiting);
+        }
+        reg.addEventListener('updatefound', ()=>{
+          const nw = reg.installing;
+          nw.addEventListener('statechange', ()=>{
+            if(nw.state === 'installed' && navigator.serviceWorker.controller){
+              showUpdate(nw);
+            }
+          });
+        });
+      }).catch((err)=>console.warn('SW registration failed', err));
+
+      let refreshing = false;
+      navigator.serviceWorker.addEventListener('controllerchange', ()=>{
+        if(refreshing) return;
+        refreshing = true;
+        window.location.reload();
+      });
     });
   }
 

--- a/index.html
+++ b/index.html
@@ -159,6 +159,7 @@
         <h1>Flight Timer & Log</h1>
         <p class="subtitle">Offline PWA — your data stays in local storage</p>
       </div>
+      <button id="updateBtn" class="install-banner">Update Available</button>
       <button id="installBtn" class="install-banner">Install App</button>
     </div>
   </header>

--- a/index.html
+++ b/index.html
@@ -138,7 +138,8 @@
     }
     footer { color: var(--muted); text-align: center; padding: 24px; }
     .tiny { font-size: .8rem; }
-    .install-banner { display:none; margin-left: auto; }
+    .install-banner { display:none; }
+    header .install-banner { margin-left: auto; }
     .pill {
       display:inline-flex; align-items:center; gap:4px; padding: 2px 8px; border-radius: 999px;
       border: 1px solid var(--border); color: var(--muted); font-size: .75rem; line-height:1;
@@ -159,7 +160,6 @@
         <h1>Flight Timer & Log</h1>
         <p class="subtitle">Offline PWA — your data stays in local storage</p>
       </div>
-      <button id="updateBtn" class="install-banner">Update Available</button>
       <button id="installBtn" class="install-banner">Install App</button>
     </div>
   </header>
@@ -338,6 +338,7 @@
   </main>
 
   <footer>
+    <button id="updateBtn" class="install-banner">Update Available</button>
     <div class="tiny">Created by James Gameron</div>
     <div class="tiny">Flight Timer & Log — Version 1.0</div>
   </footer>

--- a/service-worker.js
+++ b/service-worker.js
@@ -11,7 +11,6 @@ const ASSETS = [
 ];
 
 self.addEventListener("install", (event) => {
-  self.skipWaiting();
   event.waitUntil(
     caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS))
   );
@@ -19,10 +18,18 @@ self.addEventListener("install", (event) => {
 
 self.addEventListener("activate", (event) => {
   event.waitUntil(
-    caches.keys().then((keys) =>
-      Promise.all(keys.map((k) => (k === CACHE_NAME ? null : caches.delete(k))))
-    )
+    caches.keys()
+      .then((keys) =>
+        Promise.all(keys.map((k) => (k === CACHE_NAME ? null : caches.delete(k))))
+      )
+      .then(() => self.clients.claim())
   );
+});
+
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
 });
 
 self.addEventListener("fetch", (event) => {


### PR DESCRIPTION
## Summary
- add an Update Available button in the header
- wire service worker to surface updates and reload after activating new worker
- support update workflow in service worker using message-based skipWaiting

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0002266948326b009569ac2a37dde