### PR TITLE
Bump version to 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Flight Timer & Log PWA (v1.0)
+# Flight Timer & Log PWA (v1.1)
 
 A lightweight offline-first PWA that logs flight time, landings, Hobbs/Tach totals, and a copyable summary. Data is saved to `localStorage`.
 
@@ -10,7 +10,7 @@ A lightweight offline-first PWA that logs flight time, landings, Hobbs/Tach tota
 - **Resets** per field/section and **Reset All** with confirmations.
 - **Summary** builder with one-click **Copy**.
 - True **PWA**: `manifest.webmanifest` + `service-worker.js` for offline.
-- Version footer: **1.0**.
+- Version footer: **1.1**.
 
 ## Run locally
 Just open `index.html` in a local web server (service workers need http/https). For example:

--- a/app.js
+++ b/app.js
@@ -1,8 +1,8 @@
-/* Flight Timer & Log PWA — Version 1.0 */
+/* Flight Timer & Log PWA — Version 1.1 */
 (function(){
 
   const $ = (sel) => document.querySelector(sel);
-  const stateKey = "ftl.state.v1.0";
+  const stateKey = "ftl.state.v1.1";
 
   const els = {
     elapsedHHMMSS: $("#elapsedHHMMSS"),
@@ -388,7 +388,7 @@
       lines.push("");
     }
     lines.push("Flight Timer & Log — Summary");
-    lines.push("Version: 1.0");
+    lines.push("Version: 1.1");
     const updated = new Date(st.meta.updatedAt);
     lines.push("Saved: " + updated.toLocaleString());
     lines.push("");

--- a/index.html
+++ b/index.html
@@ -340,7 +340,7 @@
   <footer>
     <button id="updateBtn" class="install-banner">Update Available</button>
     <div class="tiny">Created by James Gameron</div>
-    <div class="tiny">Flight Timer & Log — Version 1.0</div>
+    <div class="tiny">Flight Timer & Log — Version 1.1</div>
   </footer>
 
   <script src="app.js"></script>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
-// Flight Timer & Log — Service Worker v1.0
-const CACHE_NAME = "ftl-cache-v1.0";
+// Flight Timer & Log — Service Worker v1.1
+const CACHE_NAME = "ftl-cache-v1.1";
 const ASSETS = [
   "./",
   "./index.html",


### PR DESCRIPTION
## Summary
- update app footer and docs to version 1.1
- adjust state key, service worker cache, and export summary to new version

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0047983488326aadc12761d4f346b