### PR TITLE
feat: toggle elapsed timer format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Flight Timer & Log PWA (v1.1)
+# Flight Timer & Log PWA (v1.12)
 
 A lightweight offline-first PWA that logs flight time, landings, Hobbs/Tach totals, and a copyable summary. Data is saved to `localStorage`.
 
@@ -10,7 +10,7 @@ A lightweight offline-first PWA that logs flight time, landings, Hobbs/Tach tota
 - **Resets** per field/section and **Reset All** with confirmations.
 - **Summary** builder with one-click **Copy**.
 - True **PWA**: `manifest.webmanifest` + `service-worker.js` for offline.
-- Version footer: **1.1**.
+- Version footer: **1.12**.
 
 ## Run locally
 Just open `index.html` in a local web server (service workers need http/https). For example:

--- a/app.js
+++ b/app.js
@@ -1,14 +1,14 @@
-/* Flight Timer & Log PWA — Version 1.1 */
+/* Flight Timer & Log PWA — Version 1.12 */
 (function(){
 
   const $ = (sel) => document.querySelector(sel);
-  const stateKey = "ftl.state.v1.1";
+  const stateKey = "ftl.state.v1.12";
 
   const els = {
     elapsedHHMMSS: $("#elapsedHHMMSS"),
+    elapsedLabel: $("#elapsedLabel"),
     pausedHHMMSS: $("#pausedHHMMSS"),
     pausedLabel: $("#pausedLabel"),
-    elapsedDec: $("#elapsedDec"),
     startedAt: $("#startedAt"),
     startResumeBtn: $("#startResumeBtn"),
     pauseBtn: $("#pauseBtn"),
@@ -105,6 +105,7 @@
   // ==== TIMER ====
   let tickHandle = null;
   let showPausedDec = false;
+  let showElapsedDec = false;
 
   function now(){
     return Date.now();
@@ -171,9 +172,15 @@
 
   function renderTimer(){
     const ms = getElapsedMs();
-    els.elapsedHHMMSS.textContent = msToHHMMSS(ms);
+    const hhmmss = msToHHMMSS(ms);
     const dec = msToDec(ms);
-    els.elapsedDec.textContent = dec;
+    if(showElapsedDec){
+      els.elapsedHHMMSS.textContent = dec;
+      els.elapsedLabel.textContent = "Elapsed (Decimal)";
+    } else {
+      els.elapsedHHMMSS.textContent = hhmmss;
+      els.elapsedLabel.textContent = "Elapsed (HH:MM:SS)";
+    }
     els.sumElapsed.textContent = dec;
     const pms = getPausedMs();
     if(showPausedDec){
@@ -219,6 +226,10 @@
   els.pauseBtn.addEventListener("click", pauseTimer);
   els.resetTimerBtn.addEventListener("click", ()=>{
     if(confirm("Reset the live timer?")) resetTimer();
+  });
+  els.elapsedHHMMSS.addEventListener("click", ()=>{
+    showElapsedDec = !showElapsedDec;
+    renderTimer();
   });
   els.pausedHHMMSS.addEventListener("click", ()=>{
     showPausedDec = !showPausedDec;
@@ -388,14 +399,15 @@
       lines.push("");
     }
     lines.push("Flight Timer & Log — Summary");
-    lines.push("Version: 1.1");
+    lines.push("Version: 1.12");
     const updated = new Date(st.meta.updatedAt);
     lines.push("Saved: " + updated.toLocaleString());
     lines.push("");
     // Live timer
     if (st.timer.firstStartMs) {
-      const timerHHMM = document.getElementById("elapsedHHMMSS").textContent;
-      const timerDec = document.getElementById("elapsedDec").textContent;
+      const ms = getElapsedMs();
+      const timerHHMM = msToHHMMSS(ms);
+      const timerDec = msToDec(ms);
       const started = document.getElementById("startedAt").textContent;
       lines.push("[Live Timer]");
       lines.push("  Started: " + started);

--- a/index.html
+++ b/index.html
@@ -177,16 +177,12 @@
         <h2>Live Flight Timer</h2>
         <div class="timer-display">
           <div class="stat">
-            <label>Elapsed (HH:MM:SS)</label>
-            <div id="elapsedHHMMSS" class="value">00:00:00</div>
+            <label id="elapsedLabel">Elapsed (HH:MM:SS)</label>
+            <div id="elapsedHHMMSS" class="value toggle">00:00:00</div>
           </div>
           <div class="stat">
             <label id="pausedLabel">Paused (HH:MM:SS)</label>
             <div id="pausedHHMMSS" class="value toggle">00:00:00</div>
-          </div>
-          <div class="stat">
-            <label>Elapsed (Decimal)</label>
-            <div id="elapsedDec" class="value">0.00</div>
           </div>
           <div class="stat">
             <label>Started (Local)</label>
@@ -340,7 +336,7 @@
   <footer>
     <button id="updateBtn" class="install-banner">Update Available</button>
     <div class="tiny">Created by James Gameron</div>
-    <div class="tiny">Flight Timer & Log — Version 1.1</div>
+    <div class="tiny">Flight Timer & Log — Version 1.12</div>
   </footer>
 
   <script src="app.js"></script>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
-// Flight Timer & Log — Service Worker v1.1
-const CACHE_NAME = "ftl-cache-v1.1";
+// Flight Timer & Log — Service Worker v1.12
+const CACHE_NAME = "ftl-cache-v1.12";
 const ASSETS = [
   "./",
   "./index.html",


### PR DESCRIPTION
## Summary
- make running timer show a single value that toggles between HH:MM:SS and decimal hours on tap
- bump project to version 1.12 and update cache key

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b005cbfc9c8326a07fe8c2294c1380