### PR TITLE
Add manual update check for offline usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A lightweight offline-first PWA that logs flight time, landings, Hobbs/Tach tota
 - **Summary** builder with one-click **Copy**.
 - True **PWA**: `manifest.webmanifest` + `service-worker.js` for offline.
 - Version footer: **1.12**.
+- Manual update checks via footer button; no automatic update on load.
 
 ## Run locally
 Just open `index.html` in a local web server (service workers need http/https). For example:

--- a/app.js
+++ b/app.js
@@ -41,6 +41,7 @@
     resetAll: $("#resetAll"),
     installBtn: $("#installBtn"),
     updateBtn: $("#updateBtn"),
+    checkUpdateBtn: $("#checkUpdateBtn"),
     sumElapsed: $("#sumElapsed"),
     sumElapsedLabel: $("#sumElapsedLabel"),
     sumHobbs: $("#sumHobbs"),
@@ -115,6 +116,9 @@
   let showSumHobbsDec = true;
   let showSumTachDec = true;
   let showSumManualDec = true;
+
+  // keep a reference to the service worker registration for manual update checks
+  let swReg = null;
 
   function now(){
     return Date.now();
@@ -613,6 +617,7 @@
   if('serviceWorker' in navigator){
     window.addEventListener('load', ()=>{
       navigator.serviceWorker.register('service-worker.js').then((reg)=>{
+        swReg = reg;
         function showUpdate(worker){
           els.updateBtn.style.display = 'inline-block';
           els.updateBtn.addEventListener('click', ()=>{
@@ -630,8 +635,6 @@
             }
           });
         });
-        // Attempt to check for updates but ignore failures (e.g., offline)
-        reg.update().catch(() => {});
       }).catch((err)=>console.warn('SW registration failed', err));
 
       let refreshing = false;
@@ -642,5 +645,12 @@
       });
     });
   }
+
+  // manual check for service worker updates
+  els.checkUpdateBtn.addEventListener('click', ()=>{
+    if(swReg && navigator.onLine){
+      swReg.update().catch(()=>{});
+    }
+  });
 
 })();

--- a/index.html
+++ b/index.html
@@ -330,6 +330,7 @@
   </main>
 
   <footer>
+    <button id="checkUpdateBtn" class="ghost">Check for Updates</button>
     <button id="updateBtn" class="install-banner">Update Available</button>
     <div class="tiny">Created by James Gameron</div>
     <div class="tiny">Flight Timer & Log — Version 1.12</div>


### PR DESCRIPTION
## Summary
- Remove automatic service worker update check so the app can run fully offline
- Add persistent footer button to manually check for updates
- Document manual update process

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf10b387688326a4b2360d8b68dea7