### PR TITLE
Remove update prompts for offline mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Flight Timer & Log PWA (v1.12)
+# Flight Timer & Log PWA (v1.13)
 
 A lightweight offline-first PWA that logs flight time, landings, Hobbs/Tach totals, and a copyable summary. Data is saved to `localStorage`.
 
@@ -10,8 +10,7 @@ A lightweight offline-first PWA that logs flight time, landings, Hobbs/Tach tota
 - **Resets** per field/section and **Reset All** with confirmations.
 - **Summary** builder with one-click **Copy**.
 - True **PWA**: `manifest.webmanifest` + `service-worker.js` for offline.
-- Version footer: **1.12**.
-- Manual update checks via footer button; no automatic update on load.
+- Version footer: **1.13**.
 
 ## Run locally
 Just open `index.html` in a local web server (service workers need http/https). For example:

--- a/app.js
+++ b/app.js
@@ -1,8 +1,8 @@
-/* Flight Timer & Log PWA — Version 1.12 */
+/* Flight Timer & Log PWA — Version 1.13 */
 (function(){
 
   const $ = (sel) => document.querySelector(sel);
-  const stateKey = "ftl.state.v1.12";
+  const stateKey = "ftl.state.v1.13";
 
   const els = {
     elapsedHHMMSS: $("#elapsedHHMMSS"),
@@ -40,8 +40,7 @@
     copySummary: $("#copySummary"),
     resetAll: $("#resetAll"),
     installBtn: $("#installBtn"),
-    updateBtn: $("#updateBtn"),
-    checkUpdateBtn: $("#checkUpdateBtn"),
+    // update buttons removed for offline-only mode
     sumElapsed: $("#sumElapsed"),
     sumElapsedLabel: $("#sumElapsedLabel"),
     sumHobbs: $("#sumHobbs"),
@@ -117,8 +116,7 @@
   let showSumTachDec = true;
   let showSumManualDec = true;
 
-  // keep a reference to the service worker registration for manual update checks
-  let swReg = null;
+  // update logic removed; service worker registration is simple
 
   function now(){
     return Date.now();
@@ -470,7 +468,7 @@
       lines.push("");
     }
     lines.push("Flight Timer & Log — Summary");
-    lines.push("Version: 1.12");
+    lines.push("Version: 1.13");
     const updated = new Date(st.meta.updatedAt);
     lines.push("Saved: " + updated.toLocaleString());
     lines.push("");
@@ -616,41 +614,10 @@
   // ==== SW REGISTER ====
   if('serviceWorker' in navigator){
     window.addEventListener('load', ()=>{
-      navigator.serviceWorker.register('service-worker.js').then((reg)=>{
-        swReg = reg;
-        function showUpdate(worker){
-          els.updateBtn.style.display = 'inline-block';
-          els.updateBtn.addEventListener('click', ()=>{
-            worker.postMessage({ type: 'SKIP_WAITING' });
-          }, { once: true });
-        }
-        if(reg.waiting){
-          showUpdate(reg.waiting);
-        }
-        reg.addEventListener('updatefound', ()=>{
-          const nw = reg.installing;
-          nw.addEventListener('statechange', ()=>{
-            if(nw.state === 'installed' && navigator.serviceWorker.controller){
-              showUpdate(nw);
-            }
-          });
-        });
-      }).catch((err)=>console.warn('SW registration failed', err));
-
-      let refreshing = false;
-      navigator.serviceWorker.addEventListener('controllerchange', ()=>{
-        if(refreshing) return;
-        refreshing = true;
-        window.location.reload();
-      });
+      navigator.serviceWorker
+        .register('service-worker.js')
+        .catch((err)=>console.warn('SW registration failed', err));
     });
   }
-
-  // manual check for service worker updates
-  els.checkUpdateBtn.addEventListener('click', ()=>{
-    if(swReg && navigator.onLine){
-      swReg.update().catch(()=>{});
-    }
-  });
 
 })();

--- a/index.html
+++ b/index.html
@@ -330,10 +330,8 @@
   </main>
 
   <footer>
-    <button id="checkUpdateBtn" class="ghost">Check for Updates</button>
-    <button id="updateBtn" class="install-banner">Update Available</button>
     <div class="tiny">Created by James Gameron</div>
-    <div class="tiny">Flight Timer & Log — Version 1.12</div>
+    <div class="tiny">Flight Timer & Log — Version 1.13</div>
   </footer>
 
   <script src="app.js"></script>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
-// Flight Timer & Log — Service Worker v1.12
-const CACHE_NAME = "ftl-cache-v1.12";
+// Flight Timer & Log — Service Worker v1.13
+const CACHE_NAME = "ftl-cache-v1.13";
 const ASSETS = [
   "./",
   "./index.html",
@@ -24,12 +24,6 @@ self.addEventListener("activate", (event) => {
       )
       .then(() => self.clients.claim())
   );
-});
-
-self.addEventListener('message', (event) => {
-  if (event.data && event.data.type === 'SKIP_WAITING') {
-    self.skipWaiting();
-  }
 });
 
 self.addEventListener("fetch", (event) => {


### PR DESCRIPTION
## Summary
- strip update checks and buttons to keep PWA fully offline
- bump version to 1.13 and refresh service worker cache
- clarify documentation for offline-only usage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c03d4884ac8326a5717ef4ef6ab4db