### PR TITLE
Adjust landings counter styling and reset coverage

### DIFF
--- a/app.js
+++ b/app.js
@@ -570,7 +570,8 @@
       resetTimer();
       updateDisplayCounts();
       renderHobbs(); renderTach();
-      renderManual(); renderSummary();
+      renderManual(); renderDue();
+      renderStudent(); renderSummary();
       toast("All data cleared");
     }
   });

--- a/index.html
+++ b/index.html
@@ -113,21 +113,38 @@
     }
     .hint { color: var(--muted); font-size: .8rem; }
     .section-row { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
-    .counter { display:flex; gap: 8px; align-items:center; }
+    .counter { display:flex; gap: 12px; align-items: stretch; }
     .counter + .counter { margin-top: 12px; }
-    .count {
-      min-width: 40px;
+    .counter-info {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      gap: 6px;
+    }
+    .counter-info label {
+      font-size: 1rem;
+      color: var(--muted);
       text-align: center;
-      font-size: 1.5rem;
+    }
+    .count {
+      min-width: 120px;
+      min-height: 72px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      font-size: 2.25rem;
       font-weight: 700;
-      padding: 4px 6px;
-      border-radius: 12px;
+      padding: 12px 18px;
+      border-radius: 16px;
       background: #0b1224;
       border: 1px solid var(--border);
     }
     .counter button {
-      font-size: 2.4rem;
-      padding: 28px 40px;
+      font-size: 2.1rem;
+      padding: 24px 32px;
     }
     .copybox {
       width: 100%; min-height: 120px; resize: vertical;
@@ -202,7 +219,7 @@
         <h2>Landings</h2>
         <div class="counter">
           <button id="stdMinus" class="warn">–</button>
-          <div style="flex:1">
+          <div class="counter-info">
             <label>Student</label>
             <div id="stdCount" class="count" aria-live="polite">0</div>
           </div>
@@ -210,7 +227,7 @@
         </div>
         <div class="counter">
           <button id="instMinus" class="warn">–</button>
-          <div style="flex:1">
+          <div class="counter-info">
             <label>Instructor</label>
             <div id="instCount" class="count" aria-live="polite">0</div>
           </div>


### PR DESCRIPTION
## Summary
- enlarge the landings counter display and adjust button sizing for better visual balance
- add structured markup to center landing labels and values
- ensure the Reset All action clears the due back time and student name fields

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2bc400bbc8326bee18f011fec5dcb